### PR TITLE
Add support for storing videos and files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,8 @@ class S3Storage extends StorageBase {
     return new S3(options)
   }
 
+  // Doesn't seem to be documented, but required for using this adapter for other media file types.
+  // Seealso: https://github.com/laosb/ghos3/pull/6
   urlToPath(url) {
     return url;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,10 @@ class S3Storage extends StorageBase {
     return new S3(options)
   }
 
+  urlToPath(url) {
+    return url;
+  }
+
   async save(image: Image, targetDir?: string) {
     const directory = targetDir || this.getTargetDir(this.pathPrefix)
 


### PR DESCRIPTION
In recent versions of Ghost, the storage adapter can be used for multiple object classes (video/audio/generic files) as long as it implements the `urlToPath` function.

PR adds just one function.