### PR TITLE
docs: mark AWS access key and secret as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Largely the same, but note `signatureVersion` and `serverSideEncryption` are rem
 ### Via environment variables
 
 ```
-AWS_ACCESS_KEY_ID
-AWS_SECRET_ACCESS_KEY
 AWS_DEFAULT_REGION
+AWS_ACCESS_KEY_ID // optional
+AWS_SECRET_ACCESS_KEY // optional
 GHOST_STORAGE_ADAPTER_S3_PATH_BUCKET
 GHOST_STORAGE_ADAPTER_S3_ASSET_HOST  // optional
 GHOST_STORAGE_ADAPTER_S3_PATH_PREFIX // optional


### PR DESCRIPTION
Close #4

You already handle AWS credentials properly. See [here](https://github.com/laosb/ghos3/blob/main/src/index.ts#L113-L119).
If users simply omit both `accessKeyId` and `secretAccessKey`, aws-sdk will try IAM roles or instance profiles.

We setup the Ghost server with this plugin using AWS EKS IRSA(without `accessKeyId` and `secretAccessKey`).

