### PR TITLE
fix non-path style config. files are streamed rather than buffered

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,11 +72,11 @@ class S3Storage extends StorageBase {
     
     if(this.forcePathStyle) {
       defaultHost = `https://s3${
-        this.region === 'us-east-1' ? '' : `-${this.region}`
+        this.region === 'us-east-1' ? '' : `.${this.region}`
       }.amazonaws.com/${this.bucket}`
     } else {
       defaultHost = `https://${this.bucket}.s3${
-        this.region === 'us-east-1' ? '' : `-${this.region}`
+        this.region === 'us-east-1' ? '' : `.${this.region}`
       }.amazonaws.com`
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,21 +63,32 @@ class S3Storage extends StorageBase {
     if (!this.bucket) throw new Error('S3 bucket not specified')
 
     // Optional configurations
-    this.host =
-      process.env.GHOST_STORAGE_ADAPTER_S3_ASSET_HOST ||
-      assetHost ||
-      `https://s3${
+    this.forcePathStyle =
+      Boolean(process.env.GHOST_STORAGE_ADAPTER_S3_FORCE_PATH_STYLE) ||
+      Boolean(forcePathStyle) ||
+      false
+    
+    let defaultHost;
+    
+    if(this.forcePathStyle) {
+      defaultHost = `https://s3${
         this.region === 'us-east-1' ? '' : `-${this.region}`
       }.amazonaws.com/${this.bucket}`
+    } else {
+      defaultHost = `https://${this.bucket}.s3${
+        this.region === 'us-east-1' ? '' : `-${this.region}`
+      }.amazonaws.com`
+    }
+
+    this.host =
+      process.env.GHOST_STORAGE_ADAPTER_S3_ASSET_HOST ||
+      assetHost || defaultHost
+    
     this.pathPrefix = stripLeadingSlash(
       process.env.GHOST_STORAGE_ADAPTER_S3_PATH_PREFIX || pathPrefix || ''
     )
     this.endpoint =
       process.env.GHOST_STORAGE_ADAPTER_S3_ENDPOINT || endpoint || ''
-    this.forcePathStyle =
-      Boolean(process.env.GHOST_STORAGE_ADAPTER_S3_FORCE_PATH_STYLE) ||
-      Boolean(forcePathStyle) ||
-      false
     this.acl = (process.env.GHOST_STORAGE_ADAPTER_S3_ACL ||
       acl ||
       'public-read') as ObjectCannedACL

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
 } from '@aws-sdk/client-s3'
 import StorageBase, { type ReadOptions, type Image } from 'ghost-storage-base'
 import { join } from 'path'
-import { readFile } from 'fs/promises'
+import { createReadStream } from 'fs'
 import type { Readable } from 'stream'
 import type { Handler } from 'express'
 
@@ -152,10 +152,8 @@ class S3Storage extends StorageBase {
   async save(image: Image, targetDir?: string) {
     const directory = targetDir || this.getTargetDir(this.pathPrefix)
 
-    const [fileName, file] = await Promise.all([
-      this.getUniqueFileName(image, directory),
-      readFile(image.path),
-    ])
+    const fileName = await this.getUniqueFileName(image, directory);
+    const file = createReadStream(image.path)
 
     let config: PutObjectCommandInput = {
       ACL: this.acl,


### PR DESCRIPTION
This PR has following
- Fixed non-path style S3 config.
- Files are streamed rather than buffered to reduce memory consumption