### PR TITLE
fix: url returns double slashes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ class S3Storage extends StorageBase {
     }
     await this.s3().putObject(config)
 
-    return `${this.host}/${fileName}`
+    return `${this.host}/${stripLeadingSlash(fileName)}`
   }
 
   serve(): Handler {


### PR DESCRIPTION
Sometimes I have double slashes after host address. I think this will fix that issue.